### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/api/v1/routes/facebook_login.py
+++ b/api/v1/routes/facebook_login.py
@@ -56,4 +56,6 @@ async def facebook_login(request: OAuthToken, db: Annotated[Session, Depends(get
         )
         return response
     except Exception as e:
-        return {"status_code": 500, "message": str(e)}
+        import logging
+        logging.error("An error occurred during Facebook login", exc_info=True)
+        return {"status_code": 500, "message": "An internal server error occurred. Please try again later."}


### PR DESCRIPTION
Potential fix for [https://github.com/zxenonx/hng_boilerplate_python_fastapi_web/security/code-scanning/5](https://github.com/zxenonx/hng_boilerplate_python_fastapi_web/security/code-scanning/5)

To fix the issue, we need to ensure that exception details are not exposed to the end user. Instead, we should log the exception details on the server for debugging purposes and return a generic error message to the user. This approach maintains security while still allowing developers to diagnose issues.

Steps to fix:
1. Replace the direct use of `str(e)` in the response with a generic error message.
2. Log the exception details (e.g., stack trace) on the server using a logging mechanism.
3. Ensure that the response to the user contains no sensitive information.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
